### PR TITLE
rename eth_signed_trans and bug fix

### DIFF
--- a/lib/ethRPC.js
+++ b/lib/ethRPC.js
@@ -232,7 +232,7 @@ EthRPC.prototype.eth_codeAt = function(params, cb) {
   this.getBlock(blockHash, getCode);
 };
 
-EthRPC.prototype.eth_signed_trans = function(params, cb) {
+EthRPC.prototype.eth_signedTransact = function(params, cb) {
 
   var raw = new Buffer(params[0], 'hex');
 
@@ -243,7 +243,11 @@ EthRPC.prototype.eth_signed_trans = function(params, cb) {
     if (!err && self.app.network) {
       self.app.network.broadcastTransactions([transaction]);
     }
-    cb(err, result.vm.returnValue.toString('hex'));
+    if (err) {
+      cb(err);
+    } else {
+      cb(null, result.vm.returnValue.toString('hex'));
+    }
   });
 };
 
@@ -338,7 +342,7 @@ function fnForMethod(method) {
     eth_countAt: EthRPC.prototype.eth_countAt, // count aka nonce
     eth_codeAt: EthRPC.prototype.eth_codeAt,
     eth_transact: notImplemented,
-    eth_signed_trans: EthRPC.prototype.eth_signed_trans,
+    eth_signedTransact: EthRPC.prototype.eth_signedTransact,
     eth_call: EthRPC.prototype.eth_call,
     eth_blockByHash: EthRPC.prototype.eth_blockByHash, //( hash : String )
     eth_blockByNumber: EthRPC.prototype.eth_blockByNumber, //( number : Integer )

--- a/test/rpc.js
+++ b/test/rpc.js
@@ -134,7 +134,7 @@ describe('basic app functions', function() {
       tx.sign(privateKey);
 
       cmd = {
-        'method': 'eth_signed_trans',
+        'method': 'eth_signedTransact',
         'params': [tx.serialize().toString('hex')],
         'jsonrpc': '2.0',
         'id': 2


### PR DESCRIPTION
* eth_signedTransact matches the naming convetion
* if there's an error, there wont be a result object to pull the vm off of, causing a crash