### PR TITLE
rpc - log filters

### DIFF
--- a/lib/ethRPC.js
+++ b/lib/ethRPC.js
@@ -41,7 +41,7 @@ module.exports = EthRPC = function(opts) {
       var filter = self.logFilters[id];
       // check for log filter match
       if (logEvent.bloom.multiCheck(filter.topics)) {
-         onLogFilterBloomMatch(filter, logEvent, id)
+        onLogFilterBloomMatch(filter, logEvent, id)
       }
     }
   });
@@ -51,6 +51,8 @@ module.exports = EthRPC = function(opts) {
       //push to the filter queue
       var match = true;
       var logTopics = log[1];
+      // add address as topic
+      logTopics.push(log[0]);
 
       filter.topics.forEach(function(filterTopic) {
         var filterMatch = false
@@ -479,8 +481,12 @@ EthRPC.prototype.eth_newFilter = function(params, cb) {
   var id = crypto.randomBytes(8).toString('hex');
   var filter = params[0];
   
-  var topics = filter.topic || [];
-  topics = topics.map(function(t){
+  var topics = filter.topics || [];
+  topics = topics
+  .filter(function(item){
+    return !!item;
+  })
+  .map(function(t){
     return normalizeHexString(t);
   })
 
@@ -491,6 +497,7 @@ EthRPC.prototype.eth_newFilter = function(params, cb) {
   };
 
   cb(null, id);
+
 };
 
 EthRPC.prototype.eth_newBlockFilter = function(params, cb) {
@@ -516,6 +523,20 @@ EthRPC.prototype.eth_getFilterChanges = function(params, cb) {
   if (filter) {
     cb(null, filter.results);
     filter.results = [];
+  } else {
+    cb(new Error('No filter for id: "'+filterId+'"'));
+  }
+};
+
+EthRPC.prototype.eth_getFilterLogs = function(params, cb) {
+  var self = this;
+  var filterId = params[0];
+  var filter = self.logFilters[filterId]
+    || self.blockFilters.pending[filterId]
+    || self.blockFilters.latest[filterId];
+
+  if (filter) {
+    cb(null, filter.results);
   } else {
     cb(new Error('No filter for id: "'+filterId+'"'));
   }
@@ -598,7 +619,7 @@ function fnForMethod(method) {
     eth_newBlockFilter: EthRPC.prototype.eth_newBlockFilter,
     eth_uninstallFilter: EthRPC.prototype.eth_uninstallFilter,
     eth_getFilterChanges: EthRPC.prototype.eth_getFilterChanges,
-    eth_getFilterLogs: notImplemented,
+    eth_getFilterLogs: EthRPC.prototype.eth_getFilterLogs,
     net_listening: EthRPC.prototype.net_listening,
     db_put: notImplemented,
     db_get: notImplemented,


### PR DESCRIPTION
`eth_getFilterLogs` isnt entirely to spec...

its supposed to do the same as `eth_getFilterChanges` but w/o a sense of what changed since the last request. so i just made it not clear history... good enough for now

`eth_newFilter` was looking at the wrong key so fixed that
also added address as implicit log topic


yay :smile_cat: 
